### PR TITLE
fix: fix panic if worker is not specified

### DIFF
--- a/deploy/kubernetes_operator/pkg/apis/fedlearner.k8s.io/v1alpha1/types.go
+++ b/deploy/kubernetes_operator/pkg/apis/fedlearner.k8s.io/v1alpha1/types.go
@@ -63,7 +63,7 @@ const (
 type ReplicaSpec struct {
 	// Replicas is the desired number of replicas of the given template.
 	// +optional
-	// Defaults to 1.
+	// Defaults to 0.
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Pair, when set to true, controller will try to pair it with peer controller.
 	// +optional

--- a/deploy/kubernetes_operator/pkg/operator/app_manager.go
+++ b/deploy/kubernetes_operator/pkg/operator/app_manager.go
@@ -560,7 +560,11 @@ func (am *appManager) syncRunningApp(ctx context.Context, app *v1alpha1.FLApp) e
 
 func (am *appManager) isAppFinished(app *v1alpha1.FLApp) bool {
 	rtypeWorker := v1alpha1.FLReplicaTypeWorker
-	return app.Status.FLReplicaStatus[rtypeWorker].Succeeded.Len() == getReplicas(app, rtypeWorker)
+	succeededWorkers := app.Status.FLReplicaStatus[rtypeWorker].Succeeded.Len()
+	if app.Spec.FLReplicaSpecs[rtypeWorker].Replicas == nil {
+		return succeededWorkers == 0
+	}
+	return succeededWorkers == getReplicas(app, rtypeWorker)
 }
 
 func (am *appManager) isAppFailing(app *v1alpha1.FLApp) bool {


### PR DESCRIPTION
If worker is not flReplicaSpecs, the operator will panic.