### PR TITLE
[WebConsoleV2] fix(deploy): webconsole v2 servicaccount name

### DIFF
--- a/deploy/charts/fedlearner/charts/fedlearner-web-console-v2/templates/cluster_role_binding.yaml
+++ b/deploy/charts/fedlearner/charts/fedlearner-web-console-v2/templates/cluster_role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: fedlearner-web-console-v2
+    name: {{ include "fedlearner-web-console-v2.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
## Solved Problems
ClusterRoleBinding cannot bind correctly when users execute helm with different names.
E.g. 
When naming release as `fedlearner-web-console-v2`, the charts works well. The ServiceAccount is named as `fedlearner-web-console-v2`

But installing webconsolev2 with other modules (web-console-v2 as part of `fedlearner`), the cluster role cannot bind service account. Because service account is named as `fedlearner-fedlearner-web-console-v2`.