### PR TITLE
[WebConsoleV2]: update webconsole python version to 3.7

### DIFF
--- a/.github/workflows/web-console-v2-api.yaml
+++ b/.github/workflows/web-console-v2-api.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.7'
       - name: Install dependencies
         working-directory: web_console_v2/api
         run: |


### PR DESCRIPTION
升级 WebConsoleV2 的 python 版本