### PR TITLE
fix(log): support containerd

### DIFF
--- a/deploy/charts/fedlearner-stack/charts/elastic-stack/charts/filebeat/values.yaml
+++ b/deploy/charts/fedlearner-stack/charts/elastic-stack/charts/filebeat/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: registry.cn-beijing.aliyuncs.com/fedlearner/filebeat-oss
-  tag: 7.0.1
+  repository: registry.cn-beijing.aliyuncs.com/fedlearner/filebeat
+  tag: 7.10.0
   pullPolicy: IfNotPresent
 
 config:
@@ -64,6 +64,29 @@ config:
     json.keys_under_root: true
     json.overwrite_keys: true
     json.ignore_decoding_error: true
+    # for containerd log
+  - type: log
+    enabled: true
+    paths:
+      - /var/log/pods/*/*/*.log
+    processors:
+      - script:
+          lang: javascript
+          source: >
+            function process(event){
+                var path = event.Get('log.file.path');
+                path = path.split('/');
+                var compath = path[4];
+                compath = compath.split('_')
+                event.Put('kubernetes.namespace', compath[0]);
+                event.Put('kubernetes.pod.name', compath[1]);
+                event.Put('kubernetes.container.name', path[5]);
+                var message = event.Get('message');
+                var parts = message.split(' ');
+                if (parts.length > 1 && (parts[1] == 'stdout' || parts[1] == 'stderr')) {
+                  event.Put('stream', parts[1])
+                }
+            }
 
   output.elasticsearch:
     hosts: [ "http://fedlearner-stack-elasticsearch-client:9200" ]


### PR DESCRIPTION
filebeat的配置添加了支持containerd运行时的input，升级filebeat版本到7.10。
ES query匹配的field从*变成了message，防止field数目（5000）超过7.10版本1024的限制