### PR TITLE
feat(charts): update nfs client image to solve k8s 1.20 self link issue

### DIFF
--- a/deploy/charts/fedlearner-stack/values.yaml
+++ b/deploy/charts/fedlearner-stack/values.yaml
@@ -15,7 +15,7 @@ nfs-client-provisioner:
 
   image:
     repository: registry.cn-beijing.aliyuncs.com/fedlearner/nfs-client-provisioner
-    tag: v3.1.0-k8s1.11
+    tag: v4.0.0
     pullPolicy: IfNotPresent
 
 mysql:


### PR DESCRIPTION
upgrade nfs-client-provisioner image version to compatible with kubernetes 1.20.