### PR TITLE
fix(script): parse FILE_WILDCARD env correctly

### DIFF
--- a/deploy/scripts/data_portal/run_data_portal_master.sh
+++ b/deploy/scripts/data_portal/run_data_portal_master.sh
@@ -21,7 +21,7 @@ source /app/deploy/scripts/hdfs_common.sh || true
 source /app/deploy/scripts/pre_start_hook.sh || true
 source /app/deploy/scripts/env_to_args.sh
 
-input_file_wildcard=$(normalize_env_to_args "--input_file_wildcard" $FILE_WILDCARD)
+input_file_wildcard=$(normalize_env_to_args "--input_file_wildcard" "$FILE_WILDCARD")
 kvstore_type=$(normalize_env_to_args '--kvstore_type' $KVSTORE_TYPE)
 files_per_job_limit=$(normalize_env_to_args '--files_per_job_limit' $FILES_PER_JOB_LIMIT)
 

--- a/deploy/scripts/rsa_psi/run_raw_data_partitioner.sh
+++ b/deploy/scripts/rsa_psi/run_raw_data_partitioner.sh
@@ -21,7 +21,7 @@ source /app/deploy/scripts/hdfs_common.sh || true
 source /app/deploy/scripts/env_to_args.sh
 
 partitioner_name=$(normalize_env_to_args "--partitioner_name" $NAME)
-input_file_wildcard=$(normalize_env_to_args "--input_file_wildcard" $FILE_WILDCARD)
+input_file_wildcard=$(normalize_env_to_args "--input_file_wildcard" "$FILE_WILDCARD")
 raw_data_iter=$(normalize_env_to_args "--raw_data_iter" $FILE_FORMAT)
 compressed_type=$(normalize_env_to_args "--compressed_type" $COMPRESSED_TYPE)
 read_ahead_size=$(normalize_env_to_args "--read_ahead_size" $READ_AHEAD_SIZE)


### PR DESCRIPTION
修复file wildcard解析的问题，测试代码：
```
#!/bin/bash
set -ex
normalize_env_to_args() {
  if [ -z "$2" ]
  then
      echo ""
  else
      echo "$1=$2"
  fi
  return 0
}
export FILE_WILDCARD=*
input_file_wildcard=$(normalize_env_to_args "--input_file_wildcard" "$FILE_WILDCARD")
input_file_wildcard_origin=$(normalize_env_to_args "--input_file_wildcard" $FILE_WILDCARD)
echo "--------------"
echo "$input_file_wildcard_origin"
echo "$input_file_wildcard"
```

结果：
```
+ export 'FILE_WILDCARD=*'
+ FILE_WILDCARD='*'
++ normalize_env_to_args --input_file_wildcard '*'
++ '[' -z '*' ']'
++ echo '--input_file_wildcard=*'
++ return 0
+ input_file_wildcard='--input_file_wildcard=*'
++ normalize_env_to_args --input_file_wildcard aliyun data_join data_portal env_to_args.sh etcd2mysql hdfs_common.sh pre_start_hook.sh rsa_psi trainer wait4pair_wrapper.sh xxx.sh
++ '[' -z aliyun ']'
++ echo --input_file_wildcard=aliyun
++ return 0
+ input_file_wildcard_origin=--input_file_wildcard=aliyun
+ echo --------------
--------------
+ echo --input_file_wildcard=aliyun
--input_file_wildcard=aliyun
+ echo '--input_file_wildcard=*'
--input_file_wildcard=*
```