### PR TITLE
feat(deploy): use patch2 as default spark opeartor

### DIFF
--- a/deploy/charts/fedlearner-stack/values.yaml
+++ b/deploy/charts/fedlearner-stack/values.yaml
@@ -91,7 +91,7 @@ sparkoperator:
   image:
     repository: registry.cn-beijing.aliyuncs.com/fedlearner/spark-operator
     pullPolicy: IfNotPresent
-    tag: v1beta2-1.2.0-3.0.0_patch1
+    tag: v1beta2-1.2.0-3.0.0_patch2
 
   sparkJobNamespace: default
   installCrds: true


### PR DESCRIPTION
更新 spark operator 的镜像版本。

现象：
```
Failed calling webhook, failing open webhook.sparkoperator.k8s.io: failed calling webhook "webhook.sparkoperator.k8s.io": Post "https://fedlearner-stack-webhook.default.svc:443/webhook?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

增加了生成证书的 SANS 项。
