### PR TITLE
refactor(tree): refactor to_float in tree

### DIFF
--- a/fedlearner/model/tree/trainer.py
+++ b/fedlearner/model/tree/trainer.py
@@ -217,8 +217,13 @@ def read_data(file_type, filename, require_example_ids, require_labels,
 
     features = []
     cat_features = []
+
     def to_float(x):
-        return float(x if x != '' else 'nan')
+        try:
+            return float(x)
+        except Exception as e:
+            logging.warning(f'converting data to float with error {str(e)}')
+        return float('nan')
     for line in reader:
         if file_type == 'tfrecord':
             line = parse_tfrecord(line)
@@ -228,7 +233,7 @@ def read_data(file_type, filename, require_example_ids, require_labels,
             raw_ids.append(str(line['raw_id']))
         if labels is not None:
             labels.append(float(line[label_field]))
-        features.append([to_float(line[i]) for i in cont_columns])
+        features.append([to_float(line.get(i)) for i in cont_columns])
         cat_features.append([int(line[i]) for i in cat_columns])
 
     features = np.array(features, dtype=np.float)


### PR DESCRIPTION
求交的数据如果是tfrecord并且数据字段有缺失的情况下，之前的line[xx]的方式会报错，改成line.get(xx)，然后to_float再处理一下。