### PR TITLE
chore(deploy): added metricbeat chart for metrics system

### DIFF
--- a/deploy/charts/fedlearner-stack/charts/elastic-stack/values.yaml
+++ b/deploy/charts/fedlearner-stack/charts/elastic-stack/values.yaml
@@ -23,6 +23,13 @@ filebeat:
   # indexTemplateLoad:
   #   - elastic-stack-elasticsearch-client:9200
 
+metricbeat:
+  enabled: true
+  daemonset:
+    enabled: true
+  deployment:
+    enabled: true
+
 fluentd:
   enabled: false
 

--- a/deploy/charts/fedlearner-stack/values.yaml
+++ b/deploy/charts/fedlearner-stack/values.yaml
@@ -48,6 +48,13 @@ elastic-stack:
     indexTemplateLoad:
       - "{{ .Release.Name }}-elasticsearch-client:9200"
 
+  metricbeat:
+    enabled: true
+    daemonset:
+      enabled: true
+    deployment:
+      enabled: true
+
 ingress-nginx:
   controller:
     image:

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/.helmignore
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/.helmignore
@@ -1,0 +1,2 @@
+tests/
+.pytest_cache/

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/Chart.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: Official Elastic helm chart for Metricbeat
+home: https://github.com/elastic/helm-charts
+maintainers:
+- email: helm-charts@elastic.co
+  name: Elastic
+name: metricbeat
+version: 7.15.0
+appVersion: 7.15.0
+sources:
+  - https://github.com/elastic/beats
+icon: https://helm.elastic.co/icons/beats.png

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/Makefile
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/Makefile
@@ -1,0 +1,1 @@
+include ../helpers/common.mk

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/README.md
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/README.md
@@ -1,0 +1,259 @@
+# Metricbeat Helm Chart
+
+[![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+helm-charts+master.svg)](https://devops-ci.elastic.co/job/elastic+helm-charts+master/) [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/search?repo=elastic)
+
+This Helm chart is a lightweight way to configure and run our official
+[Metricbeat Docker image][].
+
+<!-- development warning placeholder -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Requirements](#requirements)
+- [Installing](#installing)
+  - [Install released version using Helm repository](#install-released-version-using-helm-repository)
+  - [Install development version from a branch](#install-development-version-from-a-branch)
+- [Upgrading](#upgrading)
+- [Usage notes](#usage-notes)
+- [Configuration](#configuration)
+  - [Deprecated](#deprecated)
+- [FAQ](#faq)
+  - [How to use Metricbeat with Elasticsearch with security (authentication and TLS) enabled?](#how-to-use-metricbeat-with-elasticsearch-with-security-authentication-and-tls-enabled)
+  - [How to install OSS version of Metricbeat?](#how-to-install-oss-version-of-metricbeat)
+  - [How to use Kubelet read-only port instead of secure port?](#how-to-use-kubelet-read-only-port-instead-of-secure-port)
+  - [Why is Metricbeat host.name field set to Kubernetes pod name?](#why-is-metricbeat-hostname-field-set-to-kubernetes-pod-name)
+- [Contributing](#contributing)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- Use this to update TOC: -->
+<!-- docker run --rm -it -v $(pwd):/usr/src jorgeandrada/doctoc --github -->
+
+
+## Requirements
+
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
+
+See [supported configurations][] for more details.
+
+## Installing
+
+This chart is tested with the latest 7.15.0 version.
+
+### Install released version using Helm repository
+
+* Add the Elastic Helm charts repo:
+`helm repo add elastic https://helm.elastic.co`
+
+* Install it:
+  - Add the Elastic Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add stable https://charts.helm.sh/stable`
+  - with Helm 3: `helm install metricbeat --version <version> elastic/metricbeat`
+  - with Helm 2 (deprecated): `helm install --name metricbeat --version <version> elastic/metricbeat`
+
+### Install development version from a branch
+
+* Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
+
+* Checkout the branch : `git checkout 7.15`
+
+* Install it:
+  - with Helm 3: `helm install metricbeat ./helm-charts/metricbeat --set imageTag=7.15.0`
+  - with Helm 2 (deprecated): `helm install --name metricbeat ./helm-charts/metricbeat --set imageTag=7.15.0`
+
+
+## Upgrading
+
+Please always check [CHANGELOG.md][] and [BREAKING_CHANGES.md][] before
+upgrading to a new chart version.
+
+
+## Usage notes
+
+* The default Metricbeat configuration file for this chart is configured to use
+an Elasticsearch endpoint. Without any additional changes, Metricbeat will send
+documents to the service URL that the Elasticsearch Helm chart sets up by
+default. You may either set the `ELASTICSEARCH_HOSTS` environment variable in
+`extraEnvs` to override this endpoint or modify the default `metricbeatConfig`
+to change this behavior.
+* This chart disables the [HostNetwork][] setting by default for compatibility
+reasons with the majority of kubernetes providers and scenarios. Some kubernetes
+providers may not allow enabling `hostNetwork` and deploying multiple Metricbeat
+pods on the same node isn't possible with `hostNetwork` However Metricbeat does
+recommend activating it. If your kubernetes provider is compatible with
+`hostNetwork` and you don't need to run multiple Metricbeat DaemonSets, you can
+activate it by setting `hostNetworking: true` in [values.yaml][].
+* This repo includes a number of [examples][] configurations which can be used
+as a reference. They are also used in the automated testing of this chart.
+
+
+## Configuration
+
+| Parameter                      | Description                                                                                                                                                                  | Default                              |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `clusterRoleRules`             | Configurable [cluster role rules][] that Metricbeat uses to access Kubernetes resources                                                                                      | see [values.yaml][]                  |
+| `daemonset.annotations`        | Configurable [annotations][] for Metricbeat daemonset                                                                                                                        | `{}`                                 |
+| `daemonset.labels`             | Configurable [labels][] applied to all Metricbeat DaemonSet pods                                                                                                             | `{}`                                 |
+| `daemonset.affinity`           | Configurable [affinity][] for Metricbeat daemonset                                                                                                                           | `{}`                                 |
+| `daemonset.enabled`            | If true, enable daemonset                                                                                                                                                    | `true`                               |
+| `daemonset.envFrom`            | Templatable string of `envFrom` to be passed to the  [environment from variables][] which will be appended to Metricbeat container for DaemonSet                             | `[]`                                 |
+| `daemonset.extraEnvs`          | Extra [environment variables][] which will be appended to Metricbeat container for DaemonSet                                                                                 | `[]`                                 |
+| `daemonset.extraVolumeMounts`  | Templatable string of additional `volumeMounts` to be passed to the `tpl` function or DaemonSet                                                                              | `[]`                                 |
+| `daemonset.extraVolumes`       | Templatable string of additional `volumes` to be passed to the `tpl` function or DaemonSet                                                                                   | `[]`                                 |
+| `daemonset.hostAliases`        | Configurable [hostAliases][] for Metricbeat DaemonSet                                                                                                                        | `[]`                                 |
+| `daemonset.hostNetworking`     | Enable Metricbeat DaemonSet to use `hostNetwork`                                                                                                                             | `false`                              |
+| `daemonset.metricbeatConfig`   | Allows you to add any config files in `/usr/share/metricbeat` such as `metricbeat.yml` for Metricbeat DaemonSet                                                              | see [values.yaml][]                  |
+| `daemonset.nodeSelector`       | Configurable [nodeSelector][] for Metricbeat DaemonSet                                                                                                                       | `{}`                                 |
+| `daemonset.resources`          | Allows you to set the [resources][] for Metricbeat DaemonSet                                                                                                                 | see [values.yaml][]                  |
+| `daemonset.secretMounts`       | Allows you easily mount a secret as a file inside the DaemonSet. Useful for mounting certificates and other secrets. See [values.yaml][] for an example                      | `[]`                                 |
+| `daemonset.securityContext`    | Configurable [securityContext][] for Metricbeat DaemonSet pod execution environment                                                                                          | see [values.yaml][]                  |
+| `daemonset.tolerations`        | Configurable [tolerations][] for Metricbeat DaemonSet                                                                                                                        | `[]`                                 |
+| `deployment.annotations`       | Configurable [annotations][] for Metricbeat Deployment                                                                                                                       | `{}`                                 |
+| `deployment.labels`            | Configurable [labels][] applied to all Metricbeat Deployment pods                                                                                                            | `{}`                                 |
+| `deployment.affinity`          | Configurable [affinity][] for Metricbeat Deployment                                                                                                                          | `{}`                                 |
+| `deployment.enabled`           | If true, enable deployment                                                                                                                                                   | `true`                               |
+| `deployment.envFrom`           | Templatable string of `envFrom` to be passed to the  [environment from variables][] which will be appended to Metricbeat container for Deployment                            | `[]`                                 |
+| `deployment.extraEnvs`         | Extra [environment variables][] which will be appended to Metricbeat container for Deployment                                                                                | `[]`                                 |
+| `deployment.extraVolumeMounts` | Templatable string of additional `volumeMounts` to be passed to the `tpl` function or DaemonSet                                                                              | `[]`                                 |
+| `deployment.extraVolumes`      | Templatable string of additional `volumes` to be passed to the `tpl` function or Deployment                                                                                  | `[]`                                 |
+| `deployment.hostAliases`       | Configurable [hostAliases][] for Metricbeat Deployment                                                                                                                       | `[]`                                 |
+| `deployment.metricbeatConfig`  | Allows you to add any config files in `/usr/share/metricbeat` such as `metricbeat.yml` for Metricbeat Deployment                                                             | see [values.yaml][]                  |
+| `deployment.nodeSelector`      | Configurable [nodeSelector][] for Metricbeat Deployment                                                                                                                      | `{}`                                 |
+| `deployment.resources`         | Allows you to set the [resources][] for Metricbeat Deployment                                                                                                                | see [values.yaml][]                  |
+| `deployment.secretMounts`      | Allows you easily mount a secret as a file inside the Deployment Useful for mounting certificates and other secrets. See [values.yaml][] for an example                      | `[]`                                 |
+| `deployment.securityContext`   | Configurable [securityContext][] for Metricbeat Deployment pod execution environment                                                                                         | see [values.yaml][]                  |
+| `deployment.tolerations`       | Configurable [tolerations][] for Metricbeat Deployment                                                                                                                       | `[]`                                 |
+| `extraContainers`              | Templatable string of additional containers to be passed to the `tpl` function                                                                                               | `""`                                 |
+| `extraInitContainers`          | Templatable string of additional containers to be passed to the `tpl` function                                                                                               | `""`                                 |
+| `fullnameOverride`             | Overrides the full name of the resources. If not set the name will default to " `.Release.Name` - `.Values.nameOverride or .Chart.Name` "                                    | `""`                                 |
+| `hostPathRoot`                 | Fully-qualified [hostPath][] that will be used to persist Metricbeat registry data                                                                                           | `/var/lib`                           |
+| `imagePullPolicy`              | The Kubernetes [imagePullPolicy][] value                                                                                                                                     | `IfNotPresent`                       |
+| `imagePullSecrets`             | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                 | `[]`                                 |
+| `imageTag`                     | The Metricbeat Docker image tag                                                                                                                                              | `7.15.0`                    |
+| `image`                        | The Metricbeat Docker image                                                                                                                                                  | `docker.elastic.co/beats/metricbeat` |
+| `kube_state_metrics.enabled`   | Install [kube-state-metrics](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) as a dependency                                                           | `true`                               |
+| `kube_state_metrics.host`      | Define kube-state-metrics endpoint for an existing deployment. Works only if `kube_state_metrics.enabled: false`                                                             | `""`                                 |
+| `livenessProbe`                | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                                   | see [values.yaml][]                  |
+| `managedServiceAccount`        | Whether the `serviceAccount` should be managed by this helm chart. Set this to `false` in order to manage your own service account and related roles                         | `true`                               |
+| `nameOverride`                 | Overrides the chart name for resources. If not set the name will default to `.Chart.Name`                                                                                    | `""`                                 |
+| `podAnnotations`               | Configurable [annotations][] applied to all Metricbeat pods                                                                                                                  | `{}`                                 |
+| `priorityClassName`            | The name of the [PriorityClass][]. No default is supplied as the PriorityClass must be created first                                                                         | `""`                                 |
+| `readinessProbe`               | Parameters to pass to readiness [probe][] checks for values such as timeouts and thresholds                                                                                  | see [values.yaml][]                  |
+| `replicas`                     | The replica count for the Metricbeat deployment talking to kube-state-metrics                                                                                                | `1`                                  |
+| `secrets`                      | Allows creating a secret from variables or a file. To add secrets from file, add suffix `.filepath` to the key of the secret key. The value will be encoded to base64.       | See [values.yaml][]                  |
+| `serviceAccount`               | Custom [serviceAccount][] that Metricbeat will use during execution. By default will use the service account created by this chart                                           | `""`                                 |
+| `serviceAccountAnnotations`    | Annotations to be added to the ServiceAccount that is created by this chart.                                                                                                 | `{}`                                 |
+| `terminationGracePeriod`       | Termination period (in seconds) to wait before killing Metricbeat pod process on pod shutdown                                                                                | `30`                                 |
+| `updateStrategy`               | The [updateStrategy][] for the DaemonSet By default Kubernetes will kill and recreate pods on updates. Setting this to `OnDelete` will require that pods be deleted manually | `RollingUpdate`                      |
+
+### Deprecated
+
+| Parameter            | Description                                                                                                                                            | Default |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `affinity`           | Configurable [affinity][] for Metricbeat DaemonSet                                                                                                     | `{}`    |
+| `envFrom`            | Templatable string to be passed to the [environment from variables][] which will be appended to Metricbeat container for both DaemonSet and Deployment | `[]`    |
+| `extraEnvs`          | Extra [environment variables][] which will be appended to Metricbeat container for both DaemonSet and Deployment                                       | `[]`    |
+| `extraVolumeMounts`  | Templatable string of additional `volumeMounts` to be passed to the `tpl` function for both DaemonSet and Deployment                                   | `[]`    |
+| `extraVolumes`       | Templatable string of additional `volumes` to be passed to the `tpl` function for both DaemonSet and Deployment                                        | `[]`    |
+| `metricbeatConfig`   | Allows you to add any config files in `/usr/share/metricbeat` such as `metricbeat.yml` for both Metricbeat DaemonSet and Deployment                    | `{}`    |
+| `nodeSelector`       | Configurable [nodeSelector][] for Metricbeat DaemonSet                                                                                                 | `{}`    |
+| `podSecurityContext` | Configurable [securityContext][] for Metricbeat DaemonSet and Deployment pod execution environment                                                     | `{}`    |
+| `resources`          | Allows you to set the [resources][] for both Metricbeat DaemonSet and Deployment                                                                       | `{}`    |
+| `secretMounts`       | Allows you easily mount a secret as a file inside DaemonSet and Deployment Useful for mounting certificates and other secrets                          | `[]`    |
+| `tolerations`        | Configurable [tolerations][] for both Metricbeat DaemonSet and Deployment                                                                              | `[]`    |
+| `labels`             | Configurable [labels][] applied to all Metricbeat pods                                                                                                 | `[]`    |
+
+
+## FAQ
+
+### How to use Metricbeat with Elasticsearch with security (authentication and TLS) enabled?
+
+This Helm chart can use existing [Kubernetes secrets][] to setup
+credentials or certificates for examples. These secrets should be created
+outside of this chart and accessed using [environment variables][] and volumes.
+
+An example can be found in [examples/security][].
+
+### How to install OSS version of Metricbeat?
+
+Deploying OSS version of Metricbeat can be done by setting `image` value to
+[Metricbeat OSS Docker image][]
+
+An example of Metricbeat deployment using OSS version can be found in
+[examples/oss][].
+
+### How to use Kubelet read-only port instead of secure port?
+
+Default Metricbeat configuration has been switched to Kubelet secure port
+(10250/TCP) instead of read-only port (10255/TCP) in [#471][] because read-only
+port usage is now discouraged and not enabled by default in most Kubernetes
+configurations.
+
+However, if you need to use read-only port, you can replace
+`hosts: ["https://${NODE_NAME}:10250"]` by `hosts: ["${NODE_NAME}:10255"]` and
+comment `bearer_token_file` and `ssl.verification_mode` in
+`daemonset.metricbeatConfig` in [values.yaml][].
+
+### Why is Metricbeat host.name field set to Kubernetes pod name?
+
+The default Metricbeat configuration is using Metricbeat pod name for
+`agent.hostname` and `host.name` fields. The `hostname` of the Kubernetes nodes
+can be find in `kubernetes.node.name` field. If you would like to have
+`agent.hostname` and `host.name` fields set to the hostname of the nodes, you'll
+need to set `daemonset.hostNetworking` value to true.
+
+Note that enabling [hostNetwork][] make Metricbeat pod use the host network
+namespace which gives it access to the host loopback device, services listening
+on localhost, could be used to snoop on network activity of other pods on the
+same node.
+
+### How do I get multiple beats agents working with hostNetworking enabled?
+
+The default http port for multiple beats agents may be on the same port, for
+example, Filebeats and Metricbeats both default to 5066. When `hostNetworking`
+is enabled this will cause collisions when standing up the http server. The work
+around for this is to set `http.port` in the config file for one of the beats agent
+to use a different port.
+
+
+## Contributing
+
+Please check [CONTRIBUTING.md][] before any contribution or for any questions
+about our development and testing process.
+
+[7.15]: https://github.com/elastic/helm-charts/releases
+[#471]: https://github.com/elastic/helm-charts/pull/471
+[BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
+[CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
+[CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md
+[affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+[annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.15/elasticsearch/README.md#default
+[cluster role rules]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
+[environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
+[environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+[examples]: https://github.com/elastic/helm-charts/tree/7.15/metricbeat/examples
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.15/metricbeat/examples/oss
+[examples/security]: https://github.com/elastic/helm-charts/tree/7.15/metricbeat/examples/security
+[helm]: https://helm.sh
+[hostAliases]: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+[hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+[hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+[imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
+[imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+[kube-state-metrics]: https://github.com/helm/charts/tree/7.15/stable/kube-state-metrics
+[kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
+[labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[metricbeat docker image]: https://www.elastic.co/guide/en/beats/metricbeat/7.15/running-on-docker.html
+[metricbeat oss docker image]: https://www.docker.elastic.co/r/beats/metricbeat-oss
+[priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+[nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+[probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes
+[resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+[securityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+[serviceAccount]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.15/README.md#supported-configurations
+[tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+[updateStrategy]: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.15/metricbeat/values.yaml

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/requirements.lock
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kube-state-metrics
+  repository: https://charts.helm.sh/stable
+  version: 2.4.1
+digest: sha256:948dca129bc7c16b138ed8bcbdf666c324d812e43af59d475b8bb74a53e99778
+generated: "2020-10-30T18:58:57.381827+01:00"

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/requirements.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: 'kube-state-metrics'
+    version: '2.4.1'
+    repository: '@stable'
+    condition: kube_state_metrics.enabled

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/NOTES.txt
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/NOTES.txt
@@ -1,0 +1,2 @@
+1. Watch all containers come up.
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "metricbeat.fullname" . }} -w

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/_helpers.tpl
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metricbeat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "metricbeat.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Use the fullname if the serviceAccount value is not set
+*/}}
+{{- define "metricbeat.serviceAccount" -}}
+{{- if .Values.serviceAccount }}
+{{- .Values.serviceAccount -}}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/clusterrole.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metricbeat.serviceAccount" . }}-cluster-role
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+rules: {{ toYaml .Values.clusterRoleRules | nindent 2 -}}
+{{- end -}}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/clusterrolebinding.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metricbeat.serviceAccount" . }}-cluster-role-binding
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "metricbeat.serviceAccount" . }}-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metricbeat.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/configmap.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/configmap.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.metricbeatConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metricbeat.fullname" . }}-config
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+{{- range $path, $config := .Values.metricbeatConfig }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}
+{{- end -}}
+
+{{- if and .Values.daemonset.enabled .Values.daemonset.metricbeatConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metricbeat.fullname" . }}-daemonset-config
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+{{- range $path, $config := .Values.daemonset.metricbeatConfig }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}
+{{- end -}}
+
+{{- if and .Values.deployment.enabled .Values.deployment.metricbeatConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metricbeat.fullname" . }}-deployment-config
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+{{- range $path, $config := .Values.deployment.metricbeatConfig }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/daemonset.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/daemonset.yaml
@@ -1,0 +1,184 @@
+{{- if .Values.daemonset.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "metricbeat.fullname" . }}
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    {{- if .Values.daemonset.labels }}
+    {{- range $key, $value := .Values.daemonset.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- else }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.daemonset.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.daemonset.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: "{{ template "metricbeat.fullname" . }}"
+      release: {{ .Release.Name | quote }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  template:
+    metadata:
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{/* This forces a restart if the configmap has changed */}}
+        {{- if or  .Values.metricbeatConfig .Values.daemonset.metricbeatConfig }}
+        configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+      name: "{{ template "metricbeat.fullname" . }}"
+      labels:
+        app: "{{ template "metricbeat.fullname" . }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        {{- if .Values.daemonset.labels }}
+        {{- range $key, $value := .Values.daemonset.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- else }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+    spec:
+      affinity: {{ toYaml ( .Values.affinity | default .Values.daemonset.affinity ) | nindent 8 }}
+      nodeSelector: {{ toYaml ( .Values.nodeSelector | default .Values.daemonset.nodeSelector ) | nindent 8 }}
+      tolerations: {{ toYaml ( .Values.tolerations | default .Values.daemonset.tolerations ) | nindent 8 }}
+      {{- if .Values.daemonset.hostNetworking }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName  }}
+      {{- end }}
+      serviceAccountName: {{ template "metricbeat.serviceAccount" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
+      {{- if .Values.daemonset.hostAliases }}
+      hostAliases: {{ toYaml .Values.daemonset.hostAliases | nindent 6 }}
+      {{- end }}
+      volumes:
+      {{- range .Values.secretMounts | default .Values.daemonset.secretMounts }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName }}
+      {{- end }}
+      {{- if .Values.metricbeatConfig }}
+      - name: metricbeat-config
+        configMap:
+          defaultMode: 0600
+          name: {{ template "metricbeat.fullname" . }}-config
+      {{- else if .Values.daemonset.metricbeatConfig }}
+      - name: metricbeat-config
+        configMap:
+          defaultMode: 0600
+          name: {{ template "metricbeat.fullname" . }}-daemonset-config
+      {{- end }}
+      - name: data
+        hostPath:
+          path: {{ .Values.hostPathRoot }}/{{ template "metricbeat.fullname" . }}-{{ .Release.Namespace }}-data
+          type: DirectoryOrCreate
+      - name: varrundockersock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+      {{- if .Values.extraVolumes | default .Values.daemonset.extraVolumes }}
+{{ toYaml ( .Values.extraVolumes | default .Values.daemonset.extraVolumes ) | indent 6 }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- end }}
+      containers:
+      - name: "metricbeat"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        args:
+        - "-e"
+        - "-E"
+        - "http.enabled=true"
+        - "--system.hostfs=/hostfs"
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 10 }}
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}
+        resources: {{ toYaml ( .Values.resources | default .Values.daemonset.resources ) | nindent 10 }}
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{{- if .Values.extraEnvs | default .Values.daemonset.extraEnvs }}
+{{ toYaml ( .Values.extraEnvs | default .Values.daemonset.extraEnvs ) | indent 8 }}
+{{- end }}
+        envFrom: {{ toYaml ( .Values.envFrom | default .Values.daemonset.envFrom ) | nindent 10 }}
+        securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.daemonset.securityContext ) | nindent 10 }}
+        volumeMounts:
+        {{- range .Values.secretMounts | default .Values.daemonset.secretMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .path }}
+          {{- if .subPath }}
+          subPath: {{ .subPath }}
+          {{- end }}
+        {{- end }}
+        {{- range $path, $config := .Values.metricbeatConfig }}
+        - name: metricbeat-config
+          mountPath: /usr/share/metricbeat/{{ $path }}
+          readOnly: true
+          subPath: {{ $path }}
+        {{ else }}
+        {{- range $path, $config := .Values.daemonset.metricbeatConfig }}
+        - name: metricbeat-config
+          mountPath: /usr/share/metricbeat/{{ $path }}
+          readOnly: true
+          subPath: {{ $path }}
+        {{- end }}
+        {{- end }}
+        - name: data
+          mountPath: /usr/share/metricbeat/data
+        # Necessary when using autodiscovery; avoid mounting it otherwise
+        # See: https://www.elastic.co/guide/en/beats/metricbeat/7.15/configuration-autodiscover.html
+        - name: varrundockersock
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: proc
+          mountPath: /hostfs/proc
+          readOnly: true
+        - name: cgroup
+          mountPath: /hostfs/sys/fs/cgroup
+          readOnly: true
+        {{- if .Values.extraVolumeMounts | default .Values.daemonset.extraVolumeMounts }}
+{{ toYaml ( .Values.extraVolumeMounts | default .Values.daemonset.extraVolumeMounts ) | indent 8 }}
+        {{- end }}
+      {{- if .Values.extraContainers }}
+{{ tpl .Values.extraContainers . | indent 6 }}
+      {{- end }}
+{{- end }}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/deployment.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/deployment.yaml
@@ -1,0 +1,156 @@
+# Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
+{{- if .Values.deployment.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ template "metricbeat.fullname" . }}-metrics'
+  labels:
+    app: '{{ template "metricbeat.fullname" . }}-metrics'
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
+    {{- if .Values.deployment.labels }}
+    {{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- else }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.deployment.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.deployment.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: '{{ template "metricbeat.fullname" . }}-metrics'
+      release: '{{ .Release.Name }}'
+  template:
+    metadata:
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{/* This forces a restart if the configmap has changed */}}
+        {{- if or  .Values.metricbeatConfig .Values.deployment.metricbeatConfig }}
+        configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+      labels:
+        app: '{{ template "metricbeat.fullname" . }}-metrics'
+        chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+        release: '{{ .Release.Name }}'
+        {{- if .Values.deployment.labels }}
+        {{- range $key, $value := .Values.deployment.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- else }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+    spec:
+      affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      tolerations: {{ toYaml ( .Values.tolerations | default .Values.deployment.tolerations ) | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName  }}
+      {{- end }}
+      serviceAccountName: {{ template "metricbeat.serviceAccount" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
+      {{- if .Values.deployment.hostAliases }}
+      hostAliases: {{ toYaml .Values.deployment.hostAliases | nindent 6 }}
+      {{- end }}
+      volumes:
+      {{- range .Values.secretMounts | default .Values.deployment.secretMounts }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName }}
+      {{- end }}
+      {{- if .Values.metricbeatConfig }}
+      - name: metricbeat-config
+        configMap:
+          defaultMode: 0600
+          name: {{ template "metricbeat.fullname" . }}-config
+      {{- else if .Values.deployment.metricbeatConfig }}
+      - name: metricbeat-config
+        configMap:
+          defaultMode: 0600
+          name: {{ template "metricbeat.fullname" . }}-deployment-config
+      {{- end }}
+      {{- if .Values.extraVolumes | default .Values.deployment.extraVolumes }}
+{{ toYaml ( .Values.extraVolumes | default .Values.deployment.extraVolumes ) | indent 6 }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- end }}
+      containers:
+      - name: "metricbeat"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        args:
+        {{- if index .Values "metricbeatConfig" "kube-state-metrics-metricbeat.yml" }}
+          - "-c"
+          - "/usr/share/metricbeat/kube-state-metrics-metricbeat.yml"
+        {{- end }}
+          - "-e"
+          - "-E"
+          - "http.enabled=true"
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 10 }}
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}
+        resources: {{ toYaml ( .Values.resources | default .Values.deployment.resources ) | nindent 10 }}
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_STATE_METRICS_HOSTS
+          {{- if .Values.kube_state_metrics.enabled }}
+          value: "$({{ .Release.Name | replace "-" "_" | upper }}_KUBE_STATE_METRICS_SERVICE_HOST):$({{ .Release.Name | replace "-" "_" | upper }}_KUBE_STATE_METRICS_SERVICE_PORT_HTTP)"
+          {{- else }}
+          value: {{ .Values.kube_state_metrics.host | default "kube-state-metrics:8080"}}
+          {{- end }}
+{{- if .Values.extraEnvs | default .Values.deployment.extraEnvs }}
+{{ toYaml ( .Values.extraEnvs | default .Values.deployment.extraEnvs ) | indent 8 }}
+{{- end }}
+        envFrom: {{ toYaml ( .Values.envFrom | default .Values.deployment.envFrom ) | nindent 10 }}
+        securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.deployment.securityContext ) | nindent 10 }}
+        volumeMounts:
+        {{- range .Values.secretMounts | default .Values.deployment.secretMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .path }}
+          {{- if .subPath }}
+          subPath: {{ .subPath }}
+          {{- end }}
+        {{- end }}
+        {{- range $path, $config := .Values.metricbeatConfig }}
+        - name: metricbeat-config
+          mountPath: /usr/share/metricbeat/{{ $path }}
+          readOnly: true
+          subPath: {{ $path }}
+        {{ else }}
+        {{- range $path, $config := .Values.deployment.metricbeatConfig }}
+        - name: metricbeat-config
+          mountPath: /usr/share/metricbeat/{{ $path }}
+          readOnly: true
+          subPath: {{ $path }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.extraVolumeMounts | default .Values.deployment.extraVolumeMounts }}
+{{ toYaml ( .Values.extraVolumeMounts | default .Values.deployment.extraVolumeMounts ) | indent 8 }}
+        {{- end }}
+      {{- if .Values.extraContainers }}
+{{ tpl .Values.extraContainers . | indent 6 }}
+      {{- end }}
+{{- end }}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/secret.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/secret.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.secrets }}
+{{- $fullName := include "metricbeat.fullname" . -}}
+{{- range .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name | quote }}
+  labels:
+    app: {{ $fullName | quote }}
+    chart: {{ $.Chart.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
+    release: {{ $.Release.Name | quote }}
+    {{- range $key, $value := $.Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+data:
+{{- range $key, $val := .value }}
+  {{- if hasSuffix "filepath" $key }}
+  {{ $key | replace ".filepath" "" }}: {{ $.Files.Get $val | b64enc | quote }}
+  {{ else }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+{{- end }}
+type: Opaque
+{{- end }}
+{{- end }}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/service.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Release.Name }}-statsd-v1-service"
+  labels:
+    app: statsd-v1
+spec:
+  selector:
+    app: '{{ template "metricbeat.fullname" . }}-metrics'
+  ports:
+  - protocol: UDP
+    port: 8125

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/serviceaccount.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metricbeat.serviceAccount" . }}
+  annotations:
+    {{- with .Values.serviceAccountAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+{{- end -}}

--- a/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/values.yaml
+++ b/tools/deploy/charts/online/fedlearner-stack/charts/elastic-stack/charts/metricbeat/values.yaml
@@ -1,0 +1,463 @@
+---
+daemonset:
+  # Annotations to apply to the daemonset
+  annotations: { }
+  # additionals labels
+  labels: { }
+  affinity: { }
+  # Include the daemonset
+  enabled: true
+  # Extra environment variables for Metricbeat container.
+  envFrom: [ ]
+  # - configMapRef:
+  #     name: config-secret
+  extraEnvs:
+    - name: "ELASTICSEARCH_USERNAME"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: username
+    - name: "ELASTICSEARCH_PASSWORD"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: password
+    - name: "ELASTICSEARCH_HOST"
+      value: "fedlearner-stack-elasticsearch-client"
+  #  - name: MY_ENVIRONMENT_VAR
+  #    value: the_value_goes_here
+  extraVolumes: [ ]
+  # - name: extras
+  #   emptyDir: {}
+  extraVolumeMounts: [ ]
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+  hostAliases: [ ]
+  #- ip: "127.0.0.1"
+  #  hostnames:
+  #  - "foo.local"
+  #  - "bar.local"
+  hostNetworking: false
+  # Allows you to add any config files in /usr/share/metricbeat
+  # such as metricbeat.yml for daemonset
+  metricbeatConfig:
+    metricbeat.yml: |
+      metricbeat.modules:
+      - module: kubernetes
+        metricsets:
+          - container
+          - node
+          - pod
+          - system
+          - volume
+        period: 10s
+        host: "${NODE_NAME}"
+        hosts: ["https://${NODE_NAME}:10250"]
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        ssl.verification_mode: "none"
+        # If using Red Hat OpenShift remove ssl.verification_mode entry and
+        # uncomment these settings:
+        #ssl.certificate_authorities:
+          #- /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        processors:
+        - add_kubernetes_metadata: ~
+      - module: kubernetes
+        enabled: true
+        metricsets:
+          - event
+      - module: system
+        period: 10s
+        metricsets:
+          - cpu
+          - load
+          - memory
+          - network
+          - process
+          - process_summary
+        processes: ['.*']
+        process.include_top_n:
+          by_cpu: 5
+          by_memory: 5
+      - module: system
+        period: 1m
+        metricsets:
+          - filesystem
+          - fsstat
+        processors:
+        - drop_event.when.regexp:
+            system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+      output.elasticsearch:
+        hosts: '${ELASTICSEARCH_HOST:?Host env is not set}'
+        username: '${ELASTICSEARCH_USERNAME:?Username env is not set.}'
+        password: '${ELASTICSEARCH_PASSWORD:?Password env is not set.}'
+  nodeSelector: { }
+  # A list of secrets and their paths to mount inside the pod
+  # This is useful for mounting certificates for security other sensitive values
+  secretMounts: [ ]
+  #  - name: metricbeat-certificates
+  #    secretName: metricbeat-certificates
+  #    path: /usr/share/metricbeat/certs
+  # Various pod security context settings. Bear in mind that many of these have an impact on metricbeat functioning properly.
+  # - Filesystem group for the metricbeat user. The official elastic docker images always have an id of 1000.
+  # - User that the container will execute as. Typically necessary to run as root (0) in order to properly collect host container logs.
+  # - Whether to execute the metricbeat containers as privileged containers. Typically not necessarily unless running within environments such as OpenShift.
+  securityContext:
+    runAsUser: 0
+    privileged: false
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
+    limits:
+      cpu: "1000m"
+      memory: "200Mi"
+  tolerations: [ ]
+
+deployment:
+  # Annotations to apply to the deployment
+  annotations: { }
+  # additionals labels
+  labels: { }
+  affinity: { }
+  # Include the deployment
+  enabled: true
+  # Extra environment variables for Metricbeat container.
+  envFrom: [ ]
+  # - configMapRef:
+  #     name: config-secret
+  extraEnvs:
+    - name: "ELASTICSEARCH_USERNAME"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: username
+    - name: "ELASTICSEARCH_PASSWORD"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: password
+    - name: "ELASTICSEARCH_HOST"
+      value: "fedlearner-stack-elasticsearch-client"
+  #  - name: MY_ENVIRONMENT_VAR
+  #    value: the_value_goes_here
+  # Allows you to add any config files in /usr/share/metricbeat
+  extraVolumes: [ ]
+  # - name: extras
+  #   emptyDir: {}
+  extraVolumeMounts: [ ]
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+  # such as metricbeat.yml for deployment
+  hostAliases: [ ]
+  #- ip: "127.0.0.1"
+  #  hostnames:
+  #  - "foo.local"
+  #  - "bar.local"
+  metricbeatConfig:
+    metricbeat.yml: |
+      logging.level: info
+      logging.to_stderr: true
+      logging.metrics.enabled: false
+      queue:
+        mem:
+          events: 4096
+          flush.min_events: 2048
+          flush.timeout: 60s
+      metricbeat.max_start_delay: 0
+      metricbeat.modules:
+      - module: statsd
+        enabled: true
+        host: 0.0.0.0
+        port: 8125
+        ttl: 30s
+      processors:
+        - drop_fields:
+            fields: ["event", "ecs", "host", "agent", "metricset", "service"]
+            ignore_missing: true
+      output.elasticsearch:
+        enabled: true
+        hosts: '${ELASTICSEARCH_HOST:?Host env is not set}'
+        username: '${ELASTICSEARCH_USERNAME:?Username env is not set.}'
+        password: '${ELASTICSEARCH_PASSWORD:?Password env is not set.}'
+        compression_level: 9
+        max_retries: 3
+        bulk_max_size: 200
+        timeout: 120
+      # setup template
+      setup.template.json.enabled: true
+      setup.template.json.name: statsd-v1
+      setup.template.json.path: "${path.config}/template.json"
+      # setup ilm
+      setup.ilm.enabled: auto
+      setup.ilm.rollover_alias: statsd-v1
+      setup.ilm.pattern: "{now/d}-000001"
+      setup.ilm.policy_name: statsd-v1
+      setup.ilm.policy_file: "${path.config}/ilm_policy.json"
+
+    template.json: |
+      {
+        "index_patterns":[
+          "statsd-v1-*"
+        ],
+        "settings":{
+          "number_of_shards":1,
+          "number_of_replicas":1,
+          "refresh_interval":"30s",
+          "translog":{
+            "sync_interval":"2m",
+            "durability":"async"
+          },
+          "mapping":{
+            "total_fields":{
+              "limit":100000
+            }
+          },
+          "index.lifecycle.name":"statsd-v1",
+          "index.lifecycle.rollover_alias":"statsd-v1"
+        },
+        "mappings":{
+          "_source":{
+            "enabled":true
+          },
+          "date_detection":false,
+          "dynamic_templates":[
+            {
+              "labels":{
+                "path_match":"labels.*",
+                "match_mapping_type":"string",
+                "mapping":{
+                  "type":"keyword"
+                }
+              }
+            },
+            {
+              "statsd.*.count":{
+                "path_match":"statsd.*.count",
+                "match_mapping_type":"long",
+                "mapping":{
+                  "type":"long"
+                }
+              }
+            },
+            {
+              "statsd.*.*":{
+                "path_match":"statsd.*.*",
+                "mapping":{
+                  "type":"double"
+                }
+              }
+            }
+          ],
+          "dynamic":false,
+          "properties":{
+            "@timestamp":{
+              "type":"date"
+            },
+            "statsd":{
+              "dynamic":true,
+              "type":"object"
+            },
+            "labels":{
+              "dynamic":true,
+              "type":"object"
+            }
+          }
+        }
+      }
+
+    ilm_policy.json: |
+      {
+        "policy":{
+          "phases":{
+            "hot":{
+              "min_age":"0ms",
+              "actions":{
+                "rollover":{
+                  "max_age":"3d",
+                  "max_docs":10000000,
+                  "max_size":"5gb"
+                }
+              }
+            },
+            "warm":{
+              "min_age":"1d",
+              "actions":{
+                "forcemerge":{
+                  "max_num_segments":1
+                },
+                "shrink":{
+                  "number_of_shards":1
+                }
+              }
+            },
+            "delete":{
+              "min_age":"30d",
+              "actions":{
+                "delete":{
+
+                }
+              }
+            }
+          }
+        }
+      }
+
+  nodeSelector: { }
+  # A list of secrets and their paths to mount inside the pod
+  # This is useful for mounting certificates for security other sensitive values
+  secretMounts: [ ]
+  #  - name: metricbeat-certificates
+  #    secretName: metricbeat-certificates
+  #    path: /usr/share/metricbeat/certs
+  securityContext:
+    runAsUser: 0
+    privileged: false
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
+    limits:
+      cpu: "1000m"
+      memory: "200Mi"
+  tolerations: [ ]
+
+# Replicas being used for the kube-state-metrics metricbeat deployment
+replicas: 1
+
+extraContainers: ""
+# - name: dummy-init
+#   image: busybox
+#   command: ['echo', 'hey']
+
+extraInitContainers: ""
+# - name: dummy-init
+#   image: busybox
+#   command: ['echo', 'hey']
+
+# Root directory where metricbeat will write data to in order to persist registry data across pod restarts (file position and other metadata).
+hostPathRoot: /var/lib
+
+image:
+  repository: "docker.elastic.co/beats/metricbeat"
+  tag: "7.15.0"
+  pullPolicy: IfNotPresent
+
+livenessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        curl --fail 127.0.0.1:5066
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        metricbeat test output
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+# Whether this chart should self-manage its service account, role, and associated role binding.
+managedServiceAccount: true
+
+clusterRoleRules:
+  - apiGroups: [ "" ]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "extensions" ]
+    resources:
+      - replicasets
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "apps" ]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources:
+      - nodes/stats
+    verbs: [ "get" ]
+
+podAnnotations: { }
+# iam.amazonaws.com/role: es-cluster
+
+# Custom service account override that the pod will use
+serviceAccount: ""
+
+# Annotations to add to the ServiceAccount that is created if the serviceAccount value isn't set.
+serviceAccountAnnotations: { }
+# eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/k8s.clustername.namespace.serviceaccount
+
+# How long to wait for metricbeat pods to stop gracefully
+terminationGracePeriod: 30
+
+# This is the PriorityClass settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
+updateStrategy: RollingUpdate
+
+# Override various naming aspects of this chart
+# Only edit these if you know what you're doing
+nameOverride: ""
+fullnameOverride: ""
+
+kube_state_metrics:
+  enabled: true
+  # host is used only when kube_state_metrics.enabled: false
+  host: ""
+
+# Add sensitive data to k8s secrets
+secrets:
+  - name: "elasticsearch-master-credentials"
+    value:
+      username: elastic
+      password: >-
+        ""
+#  - name: "env"
+#    value:
+#      ELASTICSEARCH_PASSWORD: "LS1CRUdJTiBgUFJJVkFURSB"
+#      api_key: ui2CsdUadTiBasRJRkl9tvNnw
+#  - name: "tls"
+#    value:
+#      ca.crt: |
+#        LS0tLS1CRUdJT0K
+#        LS0tLS1CRUdJT0K
+#        LS0tLS1CRUdJT0K
+#        LS0tLS1CRUdJT0K
+#      cert.crt: "LS0tLS1CRUdJTiBlRJRklDQVRFLS0tLS0K"
+#      cert.key.filepath: "secrets.crt" # The path to file should be relative to the `values.yaml` file.
+
+# DEPRECATED
+affinity: { }
+envFrom: [ ]
+extraEnvs: [ ]
+extraVolumes: [ ]
+extraVolumeMounts: [ ]
+# Allows you to add any config files in /usr/share/metricbeat
+# such as metricbeat.yml for both daemonset and deployment
+metricbeatConfig: { }
+nodeSelector: { }
+podSecurityContext: { }
+resources: { }
+secretMounts: [ ]
+tolerations: [ ]
+labels: { }


### PR DESCRIPTION
The metricbeat chart comes from the [official repository](https://github.com/elastic/helm-charts/tree/7.15/metricbeat) and the version is 7.15.0.

Files are slightly modified in order to adapt to our naming convention. A successfully deployed instance will be like so:

![image](https://user-images.githubusercontent.com/44930252/140861329-2217977d-d853-4266-9ffe-0928b5e14ad4.png)

On any of the pods, you can try to send a UDP packet to the service we created for you.

![image](https://user-images.githubusercontent.com/44930252/140861443-89101fd4-0663-422b-9598-1c089e17f1af.png)

For example:

```bash
echo "foo,name=kiyoshi:1|c" | nc -u -w1 fedlearner-stack-statsd-v1-service 8125
```

Wait for about 30 seconds, you can check your result on Kibana in the cluster as I did here:

![image](https://user-images.githubusercontent.com/44930252/140861863-4807d041-5c42-455b-a28b-4c90a2d4de4c.png)

StatsD has a [third-party Python library](https://pypi.org/project/statsd-tags/) that supports tags (e.g. name=kiyoshi) that you can use to help you get your hands on this new feature.
