### PR TITLE
feat(tree): add new vectorized tree prediction

### DIFF
--- a/fedlearner/model/tree/trainer.py
+++ b/fedlearner/model/tree/trainer.py
@@ -149,10 +149,9 @@ def create_argument_parser():
                         default='label',
                         help='selected label name')
     parser.add_argument('--predict-type',
-                        type=int,
-                        default=0,
-                        help='predict type')
-
+                        default='iteration',
+                        choices=['vectorization', 'iteration'],
+                        help='which type for tree prediction')
     return parser
 
 
@@ -538,7 +537,8 @@ def run(args):
             loss_type=args.loss_type,
             send_scores_to_follower=args.send_scores_to_follower,
             send_metrics_to_follower=args.send_metrics_to_follower,
-            enable_packing=args.enable_packing)
+            enable_packing=args.enable_packing,
+            predict_type=args.predict_type)
 
         if args.load_model_path:
             booster.load_saved_model(args.load_model_path)

--- a/fedlearner/model/tree/trainer.py
+++ b/fedlearner/model/tree/trainer.py
@@ -148,6 +148,10 @@ def create_argument_parser():
                         type=str,
                         default='label',
                         help='selected label name')
+    parser.add_argument('--predict-type',
+                        type=int,
+                        default=0,
+                        help='predict type')
 
     return parser
 
@@ -373,7 +377,8 @@ def test_one_file(args, bridge, booster, data_file, output_file):
         example_ids=example_ids,
         cat_features=cat_X,
         feature_names=X_names,
-        cat_feature_names=cat_X_names)
+        cat_feature_names=cat_X_names,
+        predict_type=args.predict_type)
 
     if y is not None:
         metrics = booster.loss.metrics(pred, y)

--- a/fedlearner/model/tree/trainer.py
+++ b/fedlearner/model/tree/trainer.py
@@ -380,7 +380,7 @@ def test_one_file(args, bridge, booster, data_file, output_file):
         cat_features=cat_X,
         feature_names=X_names,
         cat_feature_names=cat_X_names,
-        predict_type=args.predict_type)
+        predict_type=PredictType(args.predict_type))
 
     if y is not None:
         metrics = booster.loss.metrics(pred, y)
@@ -540,8 +540,7 @@ def run(args):
             loss_type=args.loss_type,
             send_scores_to_follower=args.send_scores_to_follower,
             send_metrics_to_follower=args.send_metrics_to_follower,
-            enable_packing=args.enable_packing,
-            predict_type=args.predict_type)
+            enable_packing=args.enable_packing)
 
         if args.load_model_path:
             booster.load_saved_model(args.load_model_path)

--- a/fedlearner/model/tree/trainer.py
+++ b/fedlearner/model/tree/trainer.py
@@ -27,7 +27,7 @@ import tensorflow.compat.v1 as tf
 
 from fedlearner.common.argparse_util import str_as_bool
 from fedlearner.trainer.bridge import Bridge
-from fedlearner.model.tree.tree import BoostingTreeEnsamble
+from fedlearner.model.tree.tree import BoostingTreeEnsamble, PredictType
 from fedlearner.model.tree.trainer_master_client import LocalTrainerMasterClient
 from fedlearner.model.tree.trainer_master_client import DataBlockInfo
 
@@ -149,8 +149,11 @@ def create_argument_parser():
                         default='label',
                         help='selected label name')
     parser.add_argument('--predict-type',
-                        default='iteration',
-                        choices=['vectorization', 'iteration'],
+                        default=PredictType.ITERATION.value,
+                        choices=[
+                            PredictType.ITERATION.value,
+                            PredictType.VECTORIZATION.value
+                            ],
                         help='which type for tree prediction')
     return parser
 

--- a/fedlearner/model/tree/tree.py
+++ b/fedlearner/model/tree/tree.py
@@ -962,13 +962,9 @@ def _assign_direction_to_node(vec: Dict, direction: np.ndarray) -> np.ndarray:
     non_leaf = ~np.tile(vec['is_leaf'], (N, 1))
     node_ids = np.tile(np.arange(node_num), (N, 1))
 
-    assignment = np.empty(0, dtype=np.bool)
-    for i, assign in enumerate(
-        selected_child[non_leaf].reshape(N, non_leaf_num)
-    ):
-        tmp = np.in1d(node_ids[i], assign)
-        assignment = np.concatenate((assignment, tmp), axis=0)
-    assignment = assignment.reshape(N, node_num)
+    tmp = [np.in1d(node_ids[i], assign) for i, assign in
+           enumerate(selected_child[non_leaf].reshape(N, non_leaf_num))]
+    assignment = np.concatenate(tmp, axis=0).reshape(N, node_num)
 
     own_id = np.arange(node_num)[vec['is_owner']]
     not_own = (~np.in1d(vec['parent'], own_id))
@@ -1012,8 +1008,8 @@ def _get_leaf_node(vec: Dict, assignment: np.ndarray) -> np.ndarray:
     Args:
         vec: vectorized information dict in a tree, refer to
              _vectorize_tree(tree)
-        assignment: the possible leaf node selection vector,
-                    shape: (N, leaf_node_num),N is number of data,
+        assignment: one hot selection vector of leaf, shape:
+                    (N, leaf_node_num),N is number of data,
                     leaf_node_num is the node num in a tree.
 
     Returns:

--- a/fedlearner/model/tree/tree.py
+++ b/fedlearner/model/tree/tree.py
@@ -927,11 +927,9 @@ def _compare_features_with_threshold(vec: Dict, features: np.ndarray,
         cat_fid = np.where(is_cat, vec['feature_id'] - features.shape[1], 0)
         cat_X = cat_features[row, cat_fid]
 
-        cat_in = np.empty(0, dtype=np.bool)
-        for i, cat_threshold in enumerate(vec['cat_threshold']):
-            tmp = ~np.in1d(cat_X[:, i], cat_threshold)
-            cat_in = np.concatenate((cat_in, tmp), axis=0)
-        cat_in = np.transpose(cat_in.reshape(node_num, N))
+        tmp = [~np.in1d(cat_X[:, i], cat_threshold) for i, cat_threshold in
+               enumerate(vec['cat_threshold'])]
+        cat_in = np.transpose(np.concatenate(tmp, axis=0).reshape(node_num, N))
 
         d = np.where(is_cont, d, cat_in)
 

--- a/fedlearner/model/tree/tree.py
+++ b/fedlearner/model/tree/tree.py
@@ -904,10 +904,10 @@ def _compare_features_with_threshold(vec: Dict, features: np.ndarray,
                       of categorical features
 
     Returns:
-        d: Comparison results of features and thresholds, True
-           to the right, False to the left, np.bool, shape:
-           (N, node_num),N is number of data, node_num is the
-           node num in a tree.
+        d: Comparison of features and thresholds, True to the
+           right, False to the left, np.bool, shape: (N, node_num),
+           N is the number of data, node_num is the node num
+           in a tree.
     """
     N = features.shape[0]
     node_num = vec['feature_id'].size

--- a/fedlearner/model/tree/tree.py
+++ b/fedlearner/model/tree/tree.py
@@ -848,7 +848,7 @@ class FollowerGrower(BaseGrower):
 def _vectorize_tree(tree):
     """
     vectorize the tree
-    Args: 
+    Args:
         tree: RegressionTreeProto
     Returns:
         vec: vectorized information dict in a tree

--- a/protocols/fedlearner/common/tree_model.proto
+++ b/protocols/fedlearner/common/tree_model.proto
@@ -69,5 +69,5 @@ message VerifyParams {
     int32 num_trees = 10;
     bool leader_no_data = 11;
     bool enable_packing = 12;
-    string predict_type = 13;
+    string predict_type_value = 13;
 }

--- a/protocols/fedlearner/common/tree_model.proto
+++ b/protocols/fedlearner/common/tree_model.proto
@@ -69,4 +69,5 @@ message VerifyParams {
     int32 num_trees = 10;
     bool leader_no_data = 11;
     bool enable_packing = 12;
+    string predict_type = 13;
 }

--- a/test/tree_model/test_tree_model.py
+++ b/test/tree_model/test_tree_model.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 
 import fedlearner as fl
-from fedlearner.model.tree.tree import BoostingTreeEnsamble
+from fedlearner.model.tree.tree import BoostingTreeEnsamble, PredictType
 from fedlearner.common import tree_model_pb2 as tree_pb2
 from sklearn.datasets import load_iris
 
@@ -54,8 +54,8 @@ class TestBoostingTree(unittest.TestCase):
             num_parallel=2,
             loss_type=loss_type)
         train_pred = booster.fit(X, y, cat_features=cat_X)
-        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type='iteration')
-        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type='vectorization')
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type=PredictType('iteration'))
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type=PredictType('vectorization'))
         np.testing.assert_almost_equal(train_pred, pred_0)
         np.testing.assert_almost_equal(train_pred, pred_1)
         return pred_0
@@ -68,8 +68,8 @@ class TestBoostingTree(unittest.TestCase):
             max_iters=3,
             max_depth=2)
         train_pred = booster.fit(X, y, cat_features=cat_X)
-        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type='iteration')
-        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type='vectorization')
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type=PredictType('iteration'))
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type=PredictType('vectorization'))
         bridge.terminate()
         np.testing.assert_almost_equal(train_pred, pred_0)
         np.testing.assert_almost_equal(train_pred, pred_1)
@@ -83,8 +83,10 @@ class TestBoostingTree(unittest.TestCase):
             max_iters=3,
             max_depth=2)
         booster.fit(X, None, cat_features=cat_X)
-        pred_0 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type='iteration')
-        pred_1 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type='vectorization')
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True,
+                                       predict_type=PredictType('iteration'))
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True,
+                                       predict_type=PredictType('vectorization'))
         bridge.terminate()
         np.testing.assert_almost_equal(pred_0, 0)
         np.testing.assert_almost_equal(pred_1, 0)

--- a/test/tree_model/test_tree_model.py
+++ b/test/tree_model/test_tree_model.py
@@ -56,8 +56,8 @@ class TestBoostingTree(unittest.TestCase):
         train_pred = booster.fit(X, y, cat_features=cat_X)
         pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type='iteration')
         pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type='vectorization')
-        np.testing.assert_almost_equal(pred_0, pred_1)
         np.testing.assert_almost_equal(train_pred, pred_0)
+        np.testing.assert_almost_equal(train_pred, pred_1)
         return pred_0
 
     def leader_test_boosting_tree_helper(self, X, y, cat_X):
@@ -71,8 +71,8 @@ class TestBoostingTree(unittest.TestCase):
         pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type='iteration')
         pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type='vectorization')
         bridge.terminate()
-        np.testing.assert_almost_equal(pred_0, pred_1)
         np.testing.assert_almost_equal(train_pred, pred_0)
+        np.testing.assert_almost_equal(train_pred, pred_1)
         return pred_0
 
     def follower_test_boosting_tree_helper(self, X, cat_X):
@@ -86,8 +86,8 @@ class TestBoostingTree(unittest.TestCase):
         pred_0 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type='iteration')
         pred_1 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type='vectorization')
         bridge.terminate()
-        np.testing.assert_almost_equal(pred_0, pred_1)
         np.testing.assert_almost_equal(pred_0, 0)
+        np.testing.assert_almost_equal(pred_1, 0)
         return pred_0
 
     def boosting_tree_helper(self, X, y, cat_X):

--- a/test/tree_model/test_tree_model.py
+++ b/test/tree_model/test_tree_model.py
@@ -54,9 +54,11 @@ class TestBoostingTree(unittest.TestCase):
             num_parallel=2,
             loss_type=loss_type)
         train_pred = booster.fit(X, y, cat_features=cat_X)
-        pred = booster.batch_predict(X, cat_features=cat_X)
-        np.testing.assert_almost_equal(train_pred, pred)
-        return pred
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type=0)
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type=1)
+        np.testing.assert_almost_equal(pred_0, pred_1)
+        np.testing.assert_almost_equal(train_pred, pred_0)
+        return pred_0
 
     def leader_test_boosting_tree_helper(self, X, y, cat_X):
         bridge = fl.trainer.bridge.Bridge(
@@ -66,10 +68,12 @@ class TestBoostingTree(unittest.TestCase):
             max_iters=3,
             max_depth=2)
         train_pred = booster.fit(X, y, cat_features=cat_X)
-        pred = booster.batch_predict(X, cat_features=cat_X)
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type=0)
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type=1)
         bridge.terminate()
-        np.testing.assert_almost_equal(train_pred, pred)
-        return pred
+        np.testing.assert_almost_equal(pred_0, pred_1)
+        np.testing.assert_almost_equal(train_pred, pred_0)
+        return pred_0
 
     def follower_test_boosting_tree_helper(self, X, cat_X):
         bridge = fl.trainer.bridge.Bridge(
@@ -79,9 +83,12 @@ class TestBoostingTree(unittest.TestCase):
             max_iters=3,
             max_depth=2)
         booster.fit(X, None, cat_features=cat_X)
-        pred = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True)
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type=0)
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type=1)
         bridge.terminate()
-        np.testing.assert_almost_equal(pred, 0)
+        np.testing.assert_almost_equal(pred_0, pred_1)
+        np.testing.assert_almost_equal(pred_0, 0)
+        return pred_0
 
     def boosting_tree_helper(self, X, y, cat_X):
         local_pred = self.local_test_boosting_tree_helper(X, y, cat_X, 'mse')

--- a/test/tree_model/test_tree_model.py
+++ b/test/tree_model/test_tree_model.py
@@ -54,8 +54,8 @@ class TestBoostingTree(unittest.TestCase):
             num_parallel=2,
             loss_type=loss_type)
         train_pred = booster.fit(X, y, cat_features=cat_X)
-        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type=0)
-        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type=1)
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type='iteration')
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type='vectorization')
         np.testing.assert_almost_equal(pred_0, pred_1)
         np.testing.assert_almost_equal(train_pred, pred_0)
         return pred_0
@@ -68,8 +68,8 @@ class TestBoostingTree(unittest.TestCase):
             max_iters=3,
             max_depth=2)
         train_pred = booster.fit(X, y, cat_features=cat_X)
-        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type=0)
-        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type=1)
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, predict_type='iteration')
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, predict_type='vectorization')
         bridge.terminate()
         np.testing.assert_almost_equal(pred_0, pred_1)
         np.testing.assert_almost_equal(train_pred, pred_0)
@@ -83,8 +83,8 @@ class TestBoostingTree(unittest.TestCase):
             max_iters=3,
             max_depth=2)
         booster.fit(X, None, cat_features=cat_X)
-        pred_0 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type=0)
-        pred_1 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type=1)
+        pred_0 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type='iteration')
+        pred_1 = booster.batch_predict(X, cat_features=cat_X, get_raw_score=True, predict_type='vectorization')
         bridge.terminate()
         np.testing.assert_almost_equal(pred_0, pred_1)
         np.testing.assert_almost_equal(pred_0, 0)


### PR DESCRIPTION
新增新的树预测方式，只需要本地遍历树，之后两方交换被选择叶子节点向量即可，不再需要每次交换遍历树的方向。