### PR TITLE
refactor(visitor): change allocate logic of DataPathVisitor

### DIFF
--- a/fedlearner/trainer/data_visitor.py
+++ b/fedlearner/trainer/data_visitor.py
@@ -196,10 +196,10 @@ class DataSourceVisitor(_DataVisitor):
 
 class DataPathVisitor(_DataVisitor):
     def __init__(self,
-                 data_path,
-                 wildcard,
-                 epoch_num=1,
-                 shuffle=False):
+                 data_path: str,
+                 wildcard: str,
+                 epoch_num: int = 1,
+                 shuffle: bool = False):
         fl_logging.info("create DataVisitor by data_path: %s", data_path)
         if not tf.io.gfile.exists(data_path):
             raise ValueError("data_path not found: %s"%data_path)
@@ -217,3 +217,13 @@ class DataPathVisitor(_DataVisitor):
         datablocks.sort()
 
         super(DataPathVisitor, self).__init__(datablocks, epoch_num, shuffle)
+
+    def _check_allocated(self, epoch: int, datablock: _RawDataBlock):
+        if epoch not in self._allocated:
+            return True
+        return datablock.data_path not in self._allocated[epoch]
+
+    def _allocate(self, epoch: int, datablock: _RawDataBlock):
+        if epoch not in self._allocated:
+            self._allocated[epoch] = set()
+        self._allocated[epoch].add(datablock.data_path)


### PR DESCRIPTION
修改DataPathVisitor记录data block被分配以及检查data block是否已被分配的逻辑，统一通过path来记录。

修改的背景是，目前对于不同的数据，data_block的id有可能一样，用path是一个比较唯一的值。