### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release-apiserver.yaml
+++ b/.github/workflows/release-apiserver.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set Short Commit Sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: whoan/docker-build-with-cache-action@v5
         with:
           username: fedlearner

--- a/.github/workflows/release-fedlearner.yaml
+++ b/.github/workflows/release-fedlearner.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set Short Commit Sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: whoan/docker-build-with-cache-action@v5
         with:
           username: fedlearner

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set Short Commit Sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: whoan/docker-build-with-cache-action@v5
         with:
           username: fedlearner

--- a/.github/workflows/tag-apiserver.yaml
+++ b/.github/workflows/tag-apiserver.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set Short Commit Sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: whoan/docker-build-with-cache-action@v5
         with:
           username: fedlearner

--- a/.github/workflows/tag-fedlearner.yaml
+++ b/.github/workflows/tag-fedlearner.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set Short Commit Sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: whoan/docker-build-with-cache-action@v5
         with:
           username: fedlearner

--- a/.github/workflows/tag-operator.yaml
+++ b/.github/workflows/tag-operator.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set Short Commit Sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - uses: whoan/docker-build-with-cache-action@v5
         with:
           username: fedlearner


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter