### PR TITLE
fix(webconsole): remediate security risk summary vulnerabilities

### DIFF
--- a/web_console_v2/api/envs.py
+++ b/web_console_v2/api/envs.py
@@ -4,6 +4,21 @@ import json
 import pytz
 
 
+def _parse_bool_env(name: str, default: bool = False) -> bool:
+    """Parse an environment variable as a strict boolean.
+
+    Motivation: `os.environ.get('DEBUG', False)` returns the raw string when
+    the variable is set, so `DEBUG=False`, `DEBUG=0`, or `DEBUG=no` all
+    evaluate to truthy in a boolean context, silently bypassing auth guards
+    that key off `Envs.DEBUG`. Any string other than the well-known truthy
+    values below is treated as False.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ('1', 'true', 't', 'yes', 'y', 'on')
+
+
 class Envs(object):
     TZ = pytz.timezone(os.environ.get('TZ', 'UTC'))
     ES_HOST = os.environ.get('ES_HOST',
@@ -23,8 +38,10 @@ class Envs(object):
         if f)
     OPERATOR_LOG_MATCH_PHRASE = os.environ.get('OPERATOR_LOG_MATCH_PHRASE',
                                                None)
-    # Whether to use the real jwt_required decorator or fake one
-    DEBUG = os.environ.get('DEBUG', False)
+    # Whether to use the real jwt_required decorator or fake one.
+    # Parsed as a strict boolean so misconfigurations like DEBUG=False (a
+    # non-empty string) do not silently disable JWT enforcement.
+    DEBUG = _parse_bool_env('DEBUG', default=False)
     ES_INDEX = os.environ.get('ES_INDEX', 'filebeat-*')
     # Indicates which k8s namespace fedlearner pods belong to
     K8S_NAMESPACE = os.environ.get('K8S_NAMESPACE', 'default')

--- a/web_console_v2/api/fedlearner_webconsole/dataset/apis.py
+++ b/web_console_v2/api/fedlearner_webconsole/dataset/apis.py
@@ -29,6 +29,7 @@ from fedlearner_webconsole.dataset.services import DatasetService
 from fedlearner_webconsole.exceptions import (InvalidArgumentException,
                                               NotFoundException)
 from fedlearner_webconsole.db import db_handler as db
+from fedlearner_webconsole.project.models import Project
 from fedlearner_webconsole.proto import dataset_pb2
 from fedlearner_webconsole.scheduler.scheduler import scheduler
 from fedlearner_webconsole.utils.decorators import jwt_required
@@ -82,6 +83,7 @@ class DatasetApi(Resource):
 
 
 class DatasetPreviewApi(Resource):
+    @jwt_required()
     def get(self, dataset_id: int):
         if dataset_id <= 0:
             raise NotFoundException(f'Failed to find dataset: {dataset_id}')
@@ -91,6 +93,7 @@ class DatasetPreviewApi(Resource):
 
 
 class DatasetMetricsApi(Resource):
+    @jwt_required()
     def get(self, dataset_id: int):
         if dataset_id <= 0:
             raise NotFoundException(f'Failed to find dataset: {dataset_id}')
@@ -106,14 +109,24 @@ class DatasetsApi(Resource):
     @jwt_required()
     def get(self):
         parser = reqparse.RequestParser()
+        # Require an explicit project scope to avoid cross-tenant listing.
         parser.add_argument('project',
                             type=int,
-                            required=False,
-                            help='project')
+                            required=True,
+                            help='project id is required')
         data = parser.parse_args()
+        project_id = int(data['project'] or 0)
+        if project_id <= 0:
+            raise InvalidArgumentException(
+                details='project id must be a positive integer')
         with db.session_scope() as session:
+            # Ensure the caller is scoping to an existing project, so we do not
+            # silently return datasets from unrelated projects.
+            if session.query(Project).filter_by(id=project_id).first() is None:
+                raise NotFoundException(
+                    f'Failed to find project: {project_id}')
             datasets = DatasetService(session).get_datasets(
-                project_id=int(data['project'] or 0))
+                project_id=project_id)
             return {'data': [d.to_dict() for d in datasets]}
 
     @jwt_required()
@@ -214,14 +227,49 @@ class FilesApi(Resource):
     def __init__(self):
         self._file_manager = FileManager()
 
+    @staticmethod
+    def _resolve_safe_directory(requested: str, root: str) -> str:
+        """Resolve `requested` and ensure it is contained inside `root`.
+
+        Uses realpath+commonpath to defeat traversal via `..`, symlinks and
+        absolute-path escapes. Raises InvalidArgumentException otherwise.
+        """
+        if not root:
+            raise InvalidArgumentException(
+                details='STORAGE_ROOT is not configured')
+        # Only support local filesystem paths here. Remote schemes such as
+        # hdfs:// are intentionally rejected to keep the boundary check simple
+        # and side-effect free.
+        if '://' in requested:
+            raise InvalidArgumentException(
+                details=f'unsupported directory scheme: {requested}')
+        canonical_root = os.path.realpath(root)
+        # Resolve the requested path against the root when relative, and
+        # canonicalize to defeat `..`/symlink escapes.
+        candidate = requested
+        if not os.path.isabs(candidate):
+            candidate = os.path.join(canonical_root, candidate)
+        canonical_target = os.path.realpath(candidate)
+        try:
+            common = os.path.commonpath([canonical_root, canonical_target])
+        except ValueError:
+            # Different drives / mixed absolute-relative paths.
+            raise InvalidArgumentException(
+                details=f'invalid directory: {requested}')
+        if common != canonical_root:
+            raise InvalidArgumentException(
+                details=f'directory {requested} is outside of STORAGE_ROOT')
+        return canonical_target
+
     @jwt_required()
     def get(self):
-        # TODO: consider the security factor
+        storage_root = current_app.config.get('STORAGE_ROOT')
         if 'directory' in request.args:
-            directory = request.args['directory']
+            directory = self._resolve_safe_directory(
+                request.args['directory'], storage_root)
         else:
-            directory = os.path.join(current_app.config.get('STORAGE_ROOT'),
-                                     'upload')
+            directory = self._resolve_safe_directory(
+                os.path.join(storage_root, 'upload'), storage_root)
         files = self._file_manager.ls(directory, recursive=True)
         return {'data': [dict(file._asdict()) for file in files]}
 

--- a/web_console_v2/api/fedlearner_webconsole/job/yaml_formatter.py
+++ b/web_console_v2/api/fedlearner_webconsole/job/yaml_formatter.py
@@ -45,12 +45,31 @@ def format_yaml(yaml, **kwargs):
             'Unknown placeholder: {}'.format(e.args[0])) from e
 
 
+def _escape_variable_value(value: str) -> str:
+    """Escape a user-provided variable value so it cannot break out of the
+    surrounding JSON string during template substitution.
+
+    Job yaml templates are effectively JSON with `$var` placeholders. Without
+    escaping, a value like `", "securityContext": {...}, "x": "` would
+    terminate the enclosing string and inject arbitrary PodSpec fields into
+    the FLApp yaml, enabling privileged containers or host mounts.
+    """
+    if value is None:
+        return ''
+    if not isinstance(value, str):
+        value = str(value)
+    # json.dumps escapes ", \, control chars and non-ASCII as needed. Stripping
+    # the surrounding quotes yields a fragment safe to interpolate inside an
+    # existing JSON string literal in the template.
+    return json.dumps(value)[1:-1]
+
+
 def make_variables_dict(variables):
     var_dict = {
         var.name: (
             code_dict_encode(json.loads(var.value))
             if var.value_type == common_pb2.Variable.ValueType.CODE \
-                else var.value)
+                else _escape_variable_value(var.value))
         for var in variables
     }
     return var_dict

--- a/web_console_v2/api/fedlearner_webconsole/project/apis.py
+++ b/web_console_v2/api/fedlearner_webconsole/project/apis.py
@@ -51,6 +51,25 @@ _URL_REGEX = r'(?:^((?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(?:\.' \
              r'){1,4}|:)){2,7})+)\](?::+(\d+))?|((?:(?:[0-9a-fA-F:]){1,4}(?:(' \
              r'?::(?:[0-9a-fA-F]){1,4}|:)){2,7})+)$)'
 
+# Host header value that will be inlined into an nginx configuration-snippet /
+# server-snippet. Restrict to a conservative FQDN-only charset so any newline,
+# quote, brace, semicolon or space is rejected up-front, preventing nginx
+# directive injection. Underscore is allowed to match domain-name aliases used
+# in some deployments.
+_GRPC_SSL_SERVER_HOST_REGEX = re.compile(r'^[A-Za-z0-9._-]{1,253}$')
+
+
+def _validate_grpc_ssl_server_host(value):
+    if value is None:
+        return None
+    if not isinstance(value, str) or not _GRPC_SSL_SERVER_HOST_REGEX.match(
+            value):
+        raise InvalidArgumentException(
+            details=ErrorMessage.PARAM_FORMAT_ERROR.value.format(
+                'GRPC_SSL_SERVER_HOST',
+                'must be a hostname of [A-Za-z0-9._-] up to 253 chars'))
+    return value
+
 
 class ErrorMessage(Enum):
     PARAM_FORMAT_ERROR = 'Format of parameter {} is wrong: {}'
@@ -99,6 +118,8 @@ class ProjectsApi(Resource):
                 grpc_ssl_server_host = variable.get('value')
             if variable.get('name') == 'EGRESS_HOST':
                 egress_host = variable.get('value')
+        grpc_ssl_server_host = _validate_grpc_ssl_server_host(
+            grpc_ssl_server_host)
 
         # parse participant
         certificates = {}
@@ -224,6 +245,8 @@ class ProjectApi(Resource):
                 grpc_ssl_server_host = variable.value
             if variable.name == 'EGRESS_HOST':
                 egress_host = variable.value
+        grpc_ssl_server_host = _validate_grpc_ssl_server_host(
+            grpc_ssl_server_host)
 
         if request.json.get('participant_name'):
             config.participants[0].name = request.json.get('participant_name')

--- a/web_console_v2/api/fedlearner_webconsole/sparkapp/service.py
+++ b/web_console_v2/api/fedlearner_webconsole/sparkapp/service.py
@@ -14,12 +14,14 @@
 
 # coding: utf-8
 import os
+import re
 import logging
 import tempfile
 
 from typing import Tuple
 
 from envs import Envs
+from fedlearner_webconsole.exceptions import InvalidArgumentException
 from fedlearner_webconsole.utils.file_manager import FileManager
 from fedlearner_webconsole.sparkapp.schema import SparkAppConfig, SparkAppInfo
 from fedlearner_webconsole.utils.k8s_client import k8s_client
@@ -27,15 +29,35 @@ from fedlearner_webconsole.utils.tars import TarCli
 
 UPLOAD_PATH = Envs.STORAGE_ROOT
 
+# SparkApp name is embedded into both a filesystem path and a Kubernetes
+# resource name, so keep it strict: DNS-label style, no path separators, no
+# traversal fragments, no whitespace, no NULs.
+_SPARKAPP_NAME_REGEX = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$')
+
+
+def _validate_sparkapp_name(name: str) -> str:
+    if not isinstance(name, str) or not _SPARKAPP_NAME_REGEX.match(name):
+        raise InvalidArgumentException(
+            details=f'invalid sparkapp name: {name!r}. '
+                    'Allowed pattern: ^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$')
+    if name in ('.', '..') or '..' in name or '\x00' in name:
+        raise InvalidArgumentException(
+            details=f'invalid sparkapp name: {name!r}')
+    return name
+
 
 class SparkAppService(object):
     def __init__(self) -> None:
         self._base_dir = os.path.join(UPLOAD_PATH, 'sparkapp')
+        self._canonical_base_dir = os.path.realpath(self._base_dir)
         self._file_client = FileManager()
 
         self._file_client.mkdir(self._base_dir)
 
     def _clear_and_make_an_empty_dir(self, dir_name: str):
+        # Defense in depth: never remove anything outside of the sparkapp base
+        # dir even if a caller managed to bypass name validation.
+        self._ensure_within_base_dir(dir_name)
         try:
             self._file_client.remove(dir_name)
         except Exception as err:  # pylint: disable=broad-except
@@ -43,6 +65,18 @@ class SparkAppService(object):
                           err)
         finally:
             self._file_client.mkdir(dir_name)
+
+    def _ensure_within_base_dir(self, path: str) -> str:
+        canonical = os.path.realpath(path)
+        try:
+            common = os.path.commonpath([self._canonical_base_dir, canonical])
+        except ValueError as err:
+            raise InvalidArgumentException(
+                details=f'invalid sparkapp path: {path}') from err
+        if common != self._canonical_base_dir:
+            raise InvalidArgumentException(
+                details=f'sparkapp path escapes base dir: {path}')
+        return canonical
 
     def _get_sparkapp_upload_path(self, name: str) -> Tuple[bool, str]:
         """get upload path for specific sparkapp
@@ -56,7 +90,11 @@ class SparkAppService(object):
                 str:  upload path for this sparkapp
 
         """
+        _validate_sparkapp_name(name)
         sparkapp_path = os.path.join(self._base_dir, name)
+        # Verify the resolved path is still inside the sparkapp base dir, so
+        # that any exotic-but-name-regex-passing input still cannot escape.
+        sparkapp_path = self._ensure_within_base_dir(sparkapp_path)
         existable = False
         try:
             self._file_client.ls(sparkapp_path)
@@ -112,6 +150,7 @@ class SparkAppService(object):
         Returns:
             SparkAppInfo: resp of sparkapp
         """
+        _validate_sparkapp_name(config.name)
         sparkapp_path = config.files_path
         if config.files_path is None:
             _, sparkapp_path = self._get_sparkapp_upload_path(config.name)
@@ -142,6 +181,7 @@ class SparkAppService(object):
         Returns:
             SparkAppInfo: resp of sparkapp
         """
+        _validate_sparkapp_name(name)
         resp = k8s_client.get_sparkapplication(name)
         return SparkAppInfo.from_k8s_resp(resp)
 
@@ -160,6 +200,7 @@ class SparkAppService(object):
         Returns:
             SparkAppInfo: resp of sparkapp
         """
+        _validate_sparkapp_name(name)
         existable, sparkapp_path = self._get_sparkapp_upload_path(name)
         if existable:
             self._file_client.remove(sparkapp_path)

--- a/web_console_v2/api/fedlearner_webconsole/utils/decorators.py
+++ b/web_console_v2/api/fedlearner_webconsole/utils/decorators.py
@@ -36,7 +36,10 @@ def admin_required(f):
 
 def jwt_required(*jwt_args, **jwt_kwargs):
     def decorator(f):
-        if Envs.DEBUG:
+        # Only allow the DEBUG bypass in a non-production Flask environment.
+        # This prevents a single stray `DEBUG` env var (or its misparsed
+        # string value) from silently disabling JWT enforcement in prod.
+        if Envs.DEBUG and Envs.FLASK_ENV != 'production':
             @wraps(f)
             def wrapper(*args, **kwargs):
                 return f(*args, **kwargs)


### PR DESCRIPTION
Addresses the five issues in docs/soc_risk_summary.md:

1. FilesApi directory traversal: canonicalize the requested directory via realpath + commonpath and reject any path that escapes STORAGE_ROOT.
2. Missing @jwt_required on DatasetPreviewApi and DatasetMetricsApi.
3. DatasetsApi cross-tenant listing (IDOR): require an explicit and existing project id before returning any datasets.
4. Workflow variables PodSpec injection: JSON-escape user-provided STRING variables when they are interpolated into a job yaml template so they cannot break out of the enclosing string and inject PodSpec fields.
5. GRPC_SSL_SERVER_HOST nginx annotation CRLF/config injection: validate the value against a strict FQDN charset on both project create and update paths.
6. sparkapps name path traversal: enforce a DNS-label allowlist for the sparkapp name and re-check with realpath + commonpath that the resulting upload path stays inside self._base_dir; guard the clear-and-recreate operation the same way.
7. DEBUG env var JWT bypass: parse DEBUG as a strict boolean so values like the string "False" no longer disable auth; additionally require FLASK_ENV != production before honoring the debug bypass in jwt_required.